### PR TITLE
fix(CustomTabs) Handle cancellation of custom tabs

### DIFF
--- a/library/src/main/java/com/evernote/client/android/EvernoteOAuthCustomTabsActivity.java
+++ b/library/src/main/java/com/evernote/client/android/EvernoteOAuthCustomTabsActivity.java
@@ -8,16 +8,19 @@ import androidx.fragment.app.FragmentActivity;
 
 public class EvernoteOAuthCustomTabsActivity extends FragmentActivity {
 
+    private boolean authorizationStarted = false;
+
     @Override
     protected void onResume() {
         super.onResume();
 
         // If this is the first run of the activity, start the authorization activity
         String url = getIntent().getStringExtra(EvernoteUtil.EXTRA_AUTHORIZATION_URL);
-        if (url != null) {
+        if (url != null && !authorizationStarted) {
             new CustomTabsIntent.Builder()
                     .build()
                     .launchUrl(this, Uri.parse(url));
+            authorizationStarted = true;
             return;
         }
 


### PR DESCRIPTION
When the user cancels the CustomTabs with the Close button or with a back gesture/button, we need to finish the OAuth activity accordingly and not restart a new CustomTabs intent. Inspired by https://github.com/openid/AppAuth-Android/blob/c6137b7db306d9c097c0d5763f3fb944cd0122d2/library/java/net/openid/appauth/AuthorizationManagementActivity.java