### PR TITLE
Fix ok http compatibility after update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,6 @@ allprojects {
 ext {
     compileSdkVersion = 34
     targetSdkVersion = compileSdkVersion
-    minSdkVersion = 19
+    minSdkVersion = 21
     buildToolsVersion = "34.0.0"
 }

--- a/demo/src/main/java/com/evernote/android/demo/LoginChecker.java
+++ b/demo/src/main/java/com/evernote/android/demo/LoginChecker.java
@@ -8,6 +8,8 @@ import android.os.Bundle;
 import com.evernote.android.demo.activity.LoginActivity;
 import com.evernote.android.demo.activity.MainActivity;
 import com.evernote.client.android.EvernoteOAuthActivity;
+import com.evernote.client.android.EvernoteOAuthCustomTabsActivity;
+import com.evernote.client.android.EvernoteOAuthCustomTabsRedirectActivity;
 import com.evernote.client.android.EvernoteSession;
 import com.evernote.client.android.login.EvernoteLoginActivity;
 
@@ -22,7 +24,9 @@ public class LoginChecker implements Application.ActivityLifecycleCallbacks {
     private static final List<Class<? extends Activity>> IGNORED_ACTIVITIES = Arrays.asList(
             LoginActivity.class,
             EvernoteLoginActivity.class,
-            EvernoteOAuthActivity.class
+            EvernoteOAuthActivity.class,
+            EvernoteOAuthCustomTabsActivity.class,
+            EvernoteOAuthCustomTabsRedirectActivity.class
     );
 
     private Intent mCachedIntent;

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
     api 'com.evernote:evernote-api:1.25.1'
     implementation 'org.scribe:scribe:1.3.7'
-    implementation "com.squareup.okhttp3:okhttp:4.11.0"
+    implementation "com.squareup.okhttp3:okhttp:5.3.2"
     implementation "androidx.annotation:annotation:1.7.0"
     implementation "androidx.fragment:fragment:1.6.2"
     implementation 'androidx.browser:browser:1.7.0'
@@ -45,7 +45,7 @@ afterEvaluate{
 
                 groupId='com.github.thegrizzlylabs'
                 artifactId = 'evernote-android-sdk'
-                version = '1.0'
+                version = '1.3.4'
             }
         }
     }

--- a/library/src/main/java/com/evernote/client/conn/mobile/DiskBackedByteStore.java
+++ b/library/src/main/java/com/evernote/client/conn/mobile/DiskBackedByteStore.java
@@ -35,8 +35,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import okhttp3.internal.Util;
-
 /**
  * Holds all the data in memory until a threshold is reached. Then it writes all the data on disk.
  *

--- a/library/src/main/java/com/evernote/client/conn/mobile/TAndroidTransport.java
+++ b/library/src/main/java/com/evernote/client/conn/mobile/TAndroidTransport.java
@@ -15,7 +15,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import okhttp3.internal.Util;
 import okio.BufferedSink;
 
 /**

--- a/library/src/main/java/com/evernote/client/conn/mobile/Util.java
+++ b/library/src/main/java/com/evernote/client/conn/mobile/Util.java
@@ -1,0 +1,17 @@
+package com.evernote.client.conn.mobile;
+
+import java.io.Closeable;
+
+public class Util {
+    public static void closeQuietly(Closeable closeable) {
+        if (closeable == null) {
+            return;
+        }
+        try {
+            closeable.close();
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception ignored) {
+        }
+    }
+}


### PR DESCRIPTION
 ## Summary

  This change fixes a runtime crash when the SDK is used with OkHttp 5.

  ## Root cause

  The SDK was calling `okhttp3.internal.Util.closeQuietly`, which is an
  internal OkHttp API. In OkHttp 5, that internal class is no longer
  available under the same binary name, which causes a
  `NoClassDefFoundError` at runtime.

  ## Changes

  - replace usages of `okhttp3.internal.Util.closeQuietly`
  - use a local close helper instead of relying on OkHttp internals
